### PR TITLE
Kingdoms & Warfare Compatibility

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -50,5 +50,6 @@
 		<script name="ActionCheckA5E" file="scripts/manager_action_check_A5E.lua" />
 		<script name="ActionSaveA5E" file="scripts/manager_action_save_A5E.lua" />
 		<script name="ActionSkillA5E" file="scripts/manager_action_skill_A5E.lua" />
+		<script name="ActionsManagerA5E" file="scripts/manager_actions_A5E.lua" />
 	</base>
 </root>

--- a/scripts/manager_action_attack_A5E.lua
+++ b/scripts/manager_action_attack_A5E.lua
@@ -3,147 +3,21 @@
 -- attribution and copyright information.
 --
 
+local modAttackOriginal;
+
 function onInit()
-	ActionsManager.unregisterModHandler("attack")
+	modAttackOriginal = ActionAttack.modAttack;
+	ActionAttack.modAttack = modAttack;
 	ActionsManager.registerModHandler("attack", modAttack);
 end
 
 function modAttack(rSource, rTarget, rRoll)
-	ActionAttack.clearCritState(rSource);
-	
-	local aAddDesc = {};
-	local aAddDice = {};
-	local nAddMod = 0;
-	
-	-- Check for opportunity attack
-	local bOpportunity = ModifierManager.getKey("ATT_OPP") or Input.isShiftPressed();
+	modAttackOriginal(rSource, rTarget, rRoll);
+	local bADV, bDIS = ActionsManagerA5E.clearAdvantage(rRoll);
 
-	if bOpportunity then
-		table.insert(aAddDesc, "[OPPORTUNITY]");
-	end
-
-	-- Check defense modifiers
-	local bCover = ModifierManager.getKey("DEF_COVER");
-	local bSuperiorCover = ModifierManager.getKey("DEF_SCOVER");
-	
-	if bSuperiorCover then
-		table.insert(aAddDesc, "[COVER -5]");
-	elseif bCover then
-		table.insert(aAddDesc, "[COVER -2]");
-	end
-	
-	local bADV = false;
-	local bDIS = false;
-	if rRoll.sDesc:match(" %[ADV%]") then
-		bADV = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[ADV%]", "");		
-	end
-	if rRoll.sDesc:match(" %[DIS%]") then
-		bDIS = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[DIS%]", "");
-	end
-
-	local aAttackFilter = {};
 	if rSource then
-		-- Determine attack type
-		local sAttackType = rRoll.sDesc:match("%[ATTACK.*%((%w+)%)%]");
-		if not sAttackType then
-			sAttackType = "M";
-		end
-
-		-- Determine ability used
-		local sActionStat = nil;
-		local sModStat = rRoll.sDesc:match("%[MOD:(%w+)%]");
-		if sModStat then
-			sActionStat = DataCommon.ability_stol[sModStat];
-		end
-		
-		-- Build attack filter
-		if sAttackType == "M" then
-			table.insert(aAttackFilter, "melee");
-		elseif sAttackType == "R" then
-			table.insert(aAttackFilter, "ranged");
-		end
-		if bOpportunity then
-			table.insert(aAttackFilter, "opportunity");
-		end
-		
-		-- Get attack effect modifiers
 		local bEffects = false;
-		local nEffectCount;
-		aAddDice, nAddMod, nEffectCount = EffectManager5E.getEffectsBonus(rSource, {"ATK"}, false, aAttackFilter, rTarget);
-		if (nEffectCount > 0) then
-			bEffects = true;
-		end
-		
-		-- Get condition modifiers
-		if EffectManager5E.hasEffect(rSource, "ADVATK", rTarget) then
-			bADV = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "ADVATK", aAttackFilter, rTarget)) > 0 then
-			bADV = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffect(rSource, "DISATK", rTarget) then
-			bDIS = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "DISATK", aAttackFilter, rTarget)) > 0 then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Blinded") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Encumbered") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Frightened") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Intoxicated") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Invisible") then
-			bEffects = true;
-			bADV = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Poisoned") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager.hasCondition(rSource, "Prone") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Restrained") then
-			bEffects = true;
-			bDIS = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Unconscious") then
-			bEffects = true;
-		end
 
-		-- Get ability modifiers
-		local nBonusStat, nBonusEffects = ActorManager5E.getAbilityEffectsBonus(rSource, sActionStat);
-		if nBonusEffects > 0 then
-			bEffects = true;
-			nAddMod = nAddMod + nBonusStat;
-		end
-		
-		-- Get exhaustion modifiers
-		local nExhaustMod, nExhaustCount = EffectManager5E.getEffectsBonus(rSource, {"EXHAUSTION"}, true);
-		if nExhaustCount > 0 then
-			bEffects = true;
-			if nExhaustMod >= 3 then
-				bDIS = true;
-			end
-		end
-		
-		-- Level Up
 		-- Get fatigue modifiers
 		local nFatigueMod, nFatigueCount = EffectManager5E.getEffectsBonus(rSource, {"FATIGUE"}, true);
 		if nFatigueCount > 0 then
@@ -190,69 +64,8 @@ function modAttack(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- Determine crit range
-		local aCritRange = EffectManager5E.getEffectsByType(rSource, "CRIT", aAttackFilter, rTarget);
-		if #aCritRange > 0 then
-			local nCritThreshold = 20;
-			for _,v in ipairs(aCritRange) do
-				if v.mod > 1 and v.mod < nCritThreshold then
-					bEffects = true;
-					nCritThreshold = v.mod;
-				end
-			end
-			if nCritThreshold < 20 then
-				local sRollCritThreshold = rRoll.sDesc:match("%[CRIT (%d+)%]");
-				local nRollCritThreshold = tonumber(sRollCritThreshold) or 20;
-				if nCritThreshold < nRollCritThreshold then
-					if rRoll.sDesc:match(" %[CRIT %d+%]") then
-						rRoll.sDesc = rRoll.sDesc:gsub(" %[CRIT %d+%]", " [CRIT " .. nCritThreshold .. "]");
-					else
-						rRoll.sDesc = rRoll.sDesc ..  " [CRIT " .. nCritThreshold .. "]";
-					end
-				end
-			end
-		end
+		ActionsManagerA5E.addEffectsTag(rRoll, bEffects);
+	end
 
-		-- If effects, then add them
-		if bEffects then
-			local sEffects = "";
-			local sMod = StringManager.convertDiceToString(aAddDice, nAddMod, true);
-			if sMod ~= "" then
-				sEffects = "[" .. Interface.getString("effects_tag") .. " " .. sMod .. "]";
-			else
-				sEffects = "[" .. Interface.getString("effects_tag") .. "]";
-			end
-			table.insert(aAddDesc, sEffects);
-		end
-
-	end
-	
-	if bSuperiorCover then
-		nAddMod = nAddMod - 5;
-	elseif bCover then
-		nAddMod = nAddMod - 2;
-	end
-	
-	local bDefADV, bDefDIS = ActorManager5E.getDefenseAdvantage(rSource, rTarget, aAttackFilter);
-	if bDefADV then
-		bADV = true;
-	end
-	if bDefDIS then
-		bDIS = true;
-	end
-	
-	if #aAddDesc > 0 then
-		rRoll.sDesc = rRoll.sDesc .. " " .. table.concat(aAddDesc, " ");
-	end
-	ActionsManager2.encodeDesktopMods(rRoll);
-	for _,vDie in ipairs(aAddDice) do
-		if vDie:sub(1,1) == "-" then
-			table.insert(rRoll.aDice, "-p" .. vDie:sub(3));
-		else
-			table.insert(rRoll.aDice, "p" .. vDie:sub(2));
-		end
-	end
-	rRoll.nMod = rRoll.nMod + nAddMod;
-	
 	ActionsManager2.encodeAdvantage(rRoll, bADV, bDIS);
 end

--- a/scripts/manager_action_check_A5E.lua
+++ b/scripts/manager_action_check_A5E.lua
@@ -3,98 +3,22 @@
 -- attribution and copyright information.
 --
 
+local modRollOriginal;
+
 function onInit()
-	ActionsManager.unregisterModHandler("check");
+	modRollOriginal = ActionCheck.modRoll;
+	ActionCheck.modRoll = modRoll;
 	ActionsManager.registerModHandler("check", modRoll);
 end
 
 function modRoll(rSource, rTarget, rRoll)
-	local aAddDesc = {};
-	local aAddDice = {};
-	local nAddMod = 0;
-	
-	local bADV = false;
-	local bDIS = false;
-	if rRoll.sDesc:match(" %[ADV%]") then
-		bADV = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[ADV%]", "");
-	end
-	if rRoll.sDesc:match(" %[DIS%]") then
-		bDIS = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[DIS%]", "");
-	end
+	modRollOriginal(rSource, rTarget, rRoll);
+	local bADV, bDIS = ActionsManagerA5E.clearAdvantage(rRoll);
 
 	if rSource then
 		local bEffects = false;
-
-		-- Get ability used
-		local sActionStat = nil;
 		local sAbility = rRoll.sDesc:match("%[CHECK%] (%w+)");
-		if not sAbility then
-			local sSkill = rRoll.sDesc:match("%[SKILL%] (%w+)");
-			if sSkill then
-				sAbility = rRoll.sDesc:match("%[MOD:(%w+)%]");
-				if sAbility then
-					sAbility = DataCommon.ability_stol[sAbility];
-				else
-					for k, v in pairs(DataCommon.skilldata) do
-						if k == sSkill then
-							sAbility = v.stat;
-						end
-					end
-				end
-			end
-		end
-		if sAbility then
-			sAbility = sAbility:lower();
-		end
-
-		-- Build filter
-		local aCheckFilter = {};
-		if sAbility then
-			table.insert(aCheckFilter, sAbility);
-		end
-
-		-- Get roll effect modifiers
-		local nEffectCount;
-		aAddDice, nAddMod, nEffectCount = EffectManager5E.getEffectsBonus(rSource, {"CHECK"}, false, aCheckFilter);
-		if (nEffectCount > 0) then
-			bEffects = true;
-		end
-		
-		-- Get condition modifiers
-		if EffectManager5E.hasEffectCondition(rSource, "ADVCHK") then
-			bADV = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "ADVCHK", aCheckFilter)) > 0 then
-			bADV = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "DISCHK") then
-			bDIS = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "DISCHK", aCheckFilter)) > 0 then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Frightened") then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Intoxicated") then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Poisoned") then
-			bDIS = true;
-			bEffects = true;
-		end
 		if StringManager.contains({ "strength", "dexterity", "constitution" }, sAbility) then
-			if EffectManager5E.hasEffectCondition(rSource, "Encumbered") then
-				bEffects = true;
-				bDIS = true;
-			end
-			-- Level Up
 			-- Get fatigue modifiers
 			local nFatigueMod, nFatigueCount = EffectManager5E.getEffectsBonus(rSource, {"FATIGUE"}, true);
 			if nFatigueCount > 0 then
@@ -105,7 +29,6 @@ function modRoll(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- Level Up
 		if StringManager.contains({ "intelligence", "wisdom", "charisma" }, sAbility) then
 			-- Get strife modifiers
 			local nStrifeMod, nStrifeCount = EffectManager5E.getEffectsBonus(rSource, {"STRIFE"}, true);
@@ -117,23 +40,6 @@ function modRoll(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- Get ability modifiers
-		local nBonusStat, nBonusEffects = ActorManager5E.getAbilityEffectsBonus(rSource, sAbility);
-		if nBonusEffects > 0 then
-			bEffects = true;
-			nAddMod = nAddMod + nBonusStat;
-		end
-		
-		-- Get exhaustion modifiers
-		local nExhaustMod, nExhaustCount = EffectManager5E.getEffectsBonus(rSource, {"EXHAUSTION"}, true);
-		if nExhaustCount > 0 then
-			bEffects = true;
-			if nExhaustMod >= 1 then
-				bDIS = true;
-			end
-		end
-		
-		-- Level Up
 		-- Check for expertise die
 		if not EffectManager5E.hasEffectCondition(rSource, "Rattled") then
 			local bExpertiseD4 = ModifierManager.getKey("EXP_D4");
@@ -164,31 +70,8 @@ function modRoll(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- If effects happened, then add note
-		if bEffects then
-			local sEffects = "";
-			local sMod = StringManager.convertDiceToString(aAddDice, nAddMod, true);
-			if sMod ~= "" then
-				sEffects = "[" .. Interface.getString("effects_tag") .. " " .. sMod .. "]";
-			else
-				sEffects = "[" .. Interface.getString("effects_tag") .. "]";
-			end
-			table.insert(aAddDesc, sEffects);
-		end
+		ActionsManagerA5E.addEffectsTag(rRoll, bEffects);
 	end
-	
-	if #aAddDesc > 0 then
-		rRoll.sDesc = rRoll.sDesc .. " " .. table.concat(aAddDesc, " ");
-	end
-	ActionsManager2.encodeDesktopMods(rRoll);
-	for _,vDie in ipairs(aAddDice) do
-		if vDie:sub(1,1) == "-" then
-			table.insert(rRoll.aDice, "-p" .. vDie:sub(3));
-		else
-			table.insert(rRoll.aDice, "p" .. vDie:sub(2));
-		end
-	end
-	rRoll.nMod = rRoll.nMod + nAddMod;
-	
+
 	ActionsManager2.encodeAdvantage(rRoll, bADV, bDIS);
 end

--- a/scripts/manager_action_skill_A5E.lua
+++ b/scripts/manager_action_skill_A5E.lua
@@ -3,8 +3,11 @@
 -- attribution and copyright information.
 --
 
+local modRollOriginal;
+
 function onInit()
-	ActionsManager.unregisterModHandler("skill");
+	modRollOriginal = ActionSkill.modRoll;
+	ActionSkill.modRoll = modRoll;
 	ActionsManager.registerModHandler("skill", modRoll);
 
 	ActionSkill.performNPCRoll = performNPCRoll;
@@ -35,116 +38,13 @@ function performNPCRoll(draginfo, rActor, sSkill, nSkill, aSkill)
 end
 
 function modRoll(rSource, rTarget, rRoll)
-	local aAddDesc = {};
-	local aAddDice = {};
-	local nAddMod = 0;
-	
-	local bADV = false;
-	local bDIS = false;
-	if rRoll.sDesc:match(" %[ADV%]") then
-		bADV = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[ADV%]", "");
-	end
-	if rRoll.sDesc:match(" %[DIS%]") then
-		bDIS = true;
-		rRoll.sDesc = rRoll.sDesc:gsub(" %[DIS%]", "");
-	end
+	modRollOriginal(rSource, rTarget, rRoll);
+	local bADV, bDIS = ActionsManagerA5E.clearAdvantage(rRoll);
 
 	if rSource then
 		local bEffects = false;
-
-		-- Get ability used
-		local sActionStat = nil;
 		local sAbility = string.match(rRoll.sDesc, "%[CHECK%] (%w+)");
-		local sSkill = StringManager.trim(string.match(rRoll.sDesc, "%[SKILL%] ([^[]+)"));
-		if not sAbility and sSkill then
-			sAbility = string.match(rRoll.sDesc, "%[MOD:(%w+)%]");
-			if sAbility then
-				sAbility = DataCommon.ability_stol[sAbility];
-			else
-				local sSkillLower = sSkill:lower();
-				for k, v in pairs(DataCommon.skilldata) do
-					if k:lower() == sSkillLower then
-						sAbility = v.stat;
-					end
-				end
-			end
-		end
-		if sAbility then
-			sAbility = string.lower(sAbility);
-		end
-
-		-- Build filters
-		local aCheckFilter = {};
-		if sAbility then
-			table.insert(aCheckFilter, sAbility);
-		end
-		local aSkillFilter = {};
-		if sSkill then
-			table.insert(aSkillFilter, sSkill:lower());
-			table.insert(aSkillFilter, sAbility);
-		end
-
-		-- Get roll effect modifiers
-		local nEffectCount;
-		aAddDice, nAddMod, nEffectCount = EffectManager5E.getEffectsBonus(rSource, {"CHECK"}, false, aCheckFilter);
-		if (nEffectCount > 0) then
-			bEffects = true;
-		end
-		local aSkillAddDice, nSkillAddMod, nSkillEffectCount = EffectManager5E.getEffectsBonus(rSource, {"SKILL"}, false, aSkillFilter);
-		if (nSkillEffectCount > 0) then
-			bEffects = true;
-			for _,v in ipairs(aSkillAddDice) do
-				table.insert(aAddDice, v);
-			end
-			nAddMod = nAddMod + nSkillAddMod;
-		end
-		
-		-- Get condition modifiers
-		if EffectManager5E.hasEffectCondition(rSource, "ADVSKILL") then
-			bADV = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "ADVSKILL", aSkillFilter)) > 0 then
-			bADV = true;
-			bEffects = true;
-		elseif EffectManager5E.hasEffectCondition(rSource, "ADVCHK") then
-			bADV = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "ADVCHK", aCheckFilter)) > 0 then
-			bADV = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "DISSKILL") then
-			bDIS = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "DISSKILL", aSkillFilter)) > 0 then
-			bDIS = true;
-			bEffects = true;
-		elseif EffectManager5E.hasEffectCondition(rSource, "DISCHK") then
-			bDIS = true;
-			bEffects = true;
-		elseif #(EffectManager5E.getEffectsByType(rSource, "DISCHK", aCheckFilter)) > 0 then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Frightened") then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Intoxicated") then
-			bDIS = true;
-			bEffects = true;
-		end
-		if EffectManager5E.hasEffectCondition(rSource, "Poisoned") then
-			bDIS = true;
-			bEffects = true;
-		end
 		if StringManager.contains({ "strength", "dexterity", "constitution" }, sAbility) then
-			if EffectManager5E.hasEffectCondition(rSource, "Encumbered") then
-				bEffects = true;
-				bDIS = true;
-			end
-			-- Level Up
 			-- Get fatigue modifiers
 			local nFatigueMod, nFatigueCount = EffectManager5E.getEffectsBonus(rSource, {"FATIGUE"}, true);
 			if nFatigueCount > 0 then
@@ -154,7 +54,7 @@ function modRoll(rSource, rTarget, rRoll)
 				end
 			end
 		end
-		-- Level Up
+
 		if StringManager.contains({ "intelligence", "wisdom", "charisma" }, sAbility) then
 			-- Get strife modifiers
 			local nStrifeMod, nStrifeCount = EffectManager5E.getEffectsBonus(rSource, {"STRIFE"}, true);
@@ -166,23 +66,6 @@ function modRoll(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- Get ability modifiers
-		local nBonusStat, nBonusEffects = ActorManager5E.getAbilityEffectsBonus(rSource, sAbility);
-		if nBonusEffects > 0 then
-			bEffects = true;
-			nAddMod = nAddMod + nBonusStat;
-		end
-		
-		-- Get exhaustion modifiers
-		local nExhaustMod, nExhaustCount = EffectManager5E.getEffectsBonus(rSource, {"EXHAUSTION"}, true);
-		if nExhaustCount > 0 then
-			bEffects = true;
-			if nExhaustMod >= 1 then
-				bDIS = true;
-			end
-		end
-		
-		-- Level Up
 		-- Check for expertise die
 		if not EffectManager5E.hasEffectCondition(rSource, "Rattled") then
 			local bExpertiseD4 = ModifierManager.getKey("EXP_D4");
@@ -215,31 +98,9 @@ function modRoll(rSource, rTarget, rRoll)
 			end
 		end
 
-		-- If effects happened, then add note
-		if bEffects then
-			local sEffects = "";
-			local sMod = StringManager.convertDiceToString(aAddDice, nAddMod, true);
-			if sMod ~= "" then
-				sEffects = "[" .. Interface.getString("effects_tag") .. " " .. sMod .. "]";
-			else
-				sEffects = "[" .. Interface.getString("effects_tag") .. "]";
-			end
-			table.insert(aAddDesc, sEffects);
-		end
+		ActionsManagerA5E.addEffectsTag(rRoll, bEffects);
 	end
-	
-	if #aAddDesc > 0 then
-		rRoll.sDesc = rRoll.sDesc .. " " .. table.concat(aAddDesc, " ");
-	end
-	ActionsManager2.encodeDesktopMods(rRoll);
-	for _,vDie in ipairs(aAddDice) do
-		if vDie:sub(1,1) == "-" then
-			table.insert(rRoll.aDice, "-p" .. vDie:sub(3));
-		else
-			table.insert(rRoll.aDice, "p" .. vDie:sub(2));
-		end
-	end
-	rRoll.nMod = rRoll.nMod + nAddMod;
-	
+
+
 	ActionsManager2.encodeAdvantage(rRoll, bADV, bDIS);
 end

--- a/scripts/manager_actions_A5E.lua
+++ b/scripts/manager_actions_A5E.lua
@@ -1,0 +1,52 @@
+--
+-- Please see the license.html file included with this distribution for
+-- attribution and copyright information.
+--
+
+function clearAdvantage(rRoll)
+	local bADV = false;
+	local bDIS = false;
+	if rRoll.sDesc:match(" %[ADV%]") then
+		bADV = true;
+		rRoll.sDesc = rRoll.sDesc:gsub(" %[ADV%]", "");
+	end
+	if rRoll.sDesc:match(" %[DIS%]") then
+		bDIS = true;
+		rRoll.sDesc = rRoll.sDesc:gsub(" %[DIS%]", "");
+	end
+
+	if (bADV and not bDIS) or (bDIS and not bADV) then
+		if #(rRoll.aDice) > 1 then
+			table.remove(rRoll.aDice, 2);
+		end
+	end
+
+	return bADV, bDIS;
+end
+
+function addEffectsTag(rRoll, bEffects, aAddDice, nAddMod)
+	if bEffects then
+		aAddDice = aAddDice or {};
+		nAddMod = nAddMod or 0;
+
+		local sEffectsTag = Interface.getString("effects_tag");
+		local sMatch, sDice = rRoll.sDesc:match("% [(" .. sEffectsTag .. ") ?([^%]]*)%]");
+		if sMatch then
+			local aDice, nMod = DiceManager.convertStringToDice(sDice);
+			rRoll.sDesc:gsub(" %[" .. sEffectsTag .. " ?[^%]]*%]", "");
+			for _,sDieType in ipairs(aDice) do
+				table.insert(aAddDice, sDieType);
+			end
+			nAddMod = nAddMod + nMod;
+		end
+
+		local sEffects;
+		local sMod = StringManager.convertDiceToString(aAddDice, nAddMod, true);
+		if sMod ~= "" then
+			sEffects = " [" .. sEffectsTag .. " " .. sMod .. "]";
+		else
+			sEffects = " [" .. sEffectsTag .. "]";
+		end
+		rRoll.sDesc = rRoll.sDesc .. sEffects;
+	end
+end


### PR DESCRIPTION
Addressed modRoll override compatibility. Rather than deleting and replacing the logic provided by the ruleset and other loaded extensions, instead the logic that was previously loaded is preserved, and then the additional logic for A5E is layered on top.